### PR TITLE
Update Selenium binary to latest release (2.45.0)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -17,12 +17,12 @@ module.exports = {
     selenium: {
       version: '2.44.0',
       download: {
-        name: 'selenium-server-standalone-2.44.0.jar',
-        url: 'http://selenium-release.storage.googleapis.com/2.44/'
+        name: 'selenium-server-standalone-2.45.0.jar',
+        url: 'http://selenium-release.storage.googleapis.com/2.45/'
       },
       binary: {
-        name: 'selenium-server-standalone-2.44.0.jar',
-        path: path.resolve(SELENIUM_BINARIES_HOME, 'selenium', '2.44.0')
+        name: 'selenium-server-standalone-2.45.0.jar',
+        path: path.resolve(SELENIUM_BINARIES_HOME, 'selenium', '2.45.0')
       }
     },
     chromedriver: {


### PR DESCRIPTION
The latest release of Selenium includes support for Firefox 36--see https://code.google.com/p/selenium/issues/detail?id=8399

Commit message:

> This version Selenium was released on February 26, 2015:
>
>https://github.com/SeleniumHQ/selenium/releases/tag/selenium-2.45.0