### PR TITLE
Make versions for downloaded binaries configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,18 @@ Here's the deal...
 
 ### selenium-server-standalone.jar
 You need to install this on any OS, so this module takes care of that.
+To manually specify which version gets installed, set the `SELENIUM_BINARIES_SERVER_STANDALONE_VERSION` environment variable (default: 2.53.0).
 
 ### ChromeDriver
 You need to install this on any OS, so this module takes care of that.
+To manually specify which version gets installed, set the `SELENIUM_BINARIES_CHROMEDRIVER_VERSION` environment variable (default: 2.21).
 
 ### IEDriver
 You only need this on windows, so this module takes care of that.
 
 In addition, you have to set registry values that deal with IE security settings.
 This module takes care of that as well.
+To manually specify which version gets installed, set the `SELENIUM_BINARIES_IEDRIVER_VERSION` environment variable (default: 2.53.0).
 
 ##LICENSE
 ``````

--- a/lib/config.js
+++ b/lib/config.js
@@ -9,24 +9,34 @@ var is64 = /x64/i.test(arch);
 var isWin = /^win/i.test(platform);
 var isMac = /^dar/i.test(platform);
 var SELENIUM_BINARIES_HOME = process.env.SELENIUM_BINARIES_HOME;
+var SELENIUM_BINARIES_SERVER_STANDALONE_VERSION = process.env.SELENIUM_BINARIES_SERVER_STANDALONE_VERSION || '2.53.0';
+var SELENIUM_BINARIES_CHROMEDRIVER_VERSION = process.env.SELENIUM_BINARIES_CHROMEDRIVER_VERSION || '2.21';
+var SELENIUM_BINARIES_IEDRIVER_VERSION = process.env.SELENIUM_BINARIES_IEDRIVER_VERSION || '2.53.0';
+
+function getMajorMinorVersion(semVer) {
+  var versionParts = semVer.split('.');
+  versionParts.pop();
+  var majorMinorVersionString = versionParts.join('.');
+  return majorMinorVersionString;
+}
 
 module.exports = {
   isWin: isWin,
   version: packageJson.version,
   binaries: {
     selenium: {
-      version: '2.53.0',
+      version: SELENIUM_BINARIES_SERVER_STANDALONE_VERSION,
       download: {
-        name: 'selenium-server-standalone-2.53.0.jar',
-        url: 'http://selenium-release.storage.googleapis.com/2.53/'
+        name: 'selenium-server-standalone-' + SELENIUM_BINARIES_SERVER_STANDALONE_VERSION + '.jar',
+        url: 'http://selenium-release.storage.googleapis.com/' + getMajorMinorVersion(SELENIUM_BINARIES_SERVER_STANDALONE_VERSION) + '/'
       },
       binary: {
-        name: 'selenium-server-standalone-2.53.0.jar',
-        path: path.resolve(SELENIUM_BINARIES_HOME, 'selenium', '2.53.0')
+        name: 'selenium-server-standalone-' + SELENIUM_BINARIES_SERVER_STANDALONE_VERSION + '.jar',
+        path: path.resolve(SELENIUM_BINARIES_HOME, 'selenium', SELENIUM_BINARIES_SERVER_STANDALONE_VERSION)
       }
     },
     chromedriver: {
-      version: '2.21',
+      version: SELENIUM_BINARIES_CHROMEDRIVER_VERSION,
       download: {
         name: 'chromedriver_'
           + ( isWin
@@ -40,27 +50,27 @@ module.exports = {
                 )
             )
           + '.zip',
-        url:'http://chromedriver.storage.googleapis.com/2.21/'
+        url:'http://chromedriver.storage.googleapis.com/' + SELENIUM_BINARIES_CHROMEDRIVER_VERSION + '/'
       },
       binary: {
         name: 'chromedriver' + ( isWin ? '.exe' : ''),
-        path: path.resolve(SELENIUM_BINARIES_HOME, 'chromedriver', '2.21')
+        path: path.resolve(SELENIUM_BINARIES_HOME, 'chromedriver', SELENIUM_BINARIES_CHROMEDRIVER_VERSION)
       }
     },
     iedriver: {
-      version: '2.53.0',
+      version: SELENIUM_BINARIES_IEDRIVER_VERSION,
       download: {
         name: 'IEDriverServer_'
           + ( is64
               ? 'x64'
               : 'Win32'
             )
-          + '_2.53.0.zip',
-        url:'http://selenium-release.storage.googleapis.com/2.53/'
+          + '_' + SELENIUM_BINARIES_IEDRIVER_VERSION + '.zip',
+        url:'http://selenium-release.storage.googleapis.com/' + getMajorMinorVersion(SELENIUM_BINARIES_IEDRIVER_VERSION) + '/'
       },
       binary: {
         name: 'IEDriverServer.exe',
-        path: path.resolve(SELENIUM_BINARIES_HOME, 'iedriver', '2.53.0')
+        path: path.resolve(SELENIUM_BINARIES_HOME, 'iedriver', SELENIUM_BINARIES_IEDRIVER_VERSION)
       }
     }
   }


### PR DESCRIPTION
This would allow users to optionally set a specific version for a binary. For example, users may want to work on a newer or older version of ChromeDriver, but don't want to wait for a pull request or use an older version of this NPM package.

**I do not have a Windows machine, so IEDriver was not tested.**

Default values are set to the existing versions in v0.4.0 for backward compatibility purposes. Since this change does not affect the API from a Node/JS perspective and is aimed mainly at compatibility use-cases, I did not consider it a new feature, so I bumped the patch version instead of the minor version. Feel free to change it, otherwise.