### PR TITLE
Updated geckodriver archive name for macOS

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -82,7 +82,7 @@ module.exports = {
       archiveName: util.format(
         'geckodriver-v%s-%s',
         SELENIUM_BINARIES_GECKODRIVER_VERSION,
-        (isWin ? 'win64.zip' : (isMac ? 'mac.tar.gz' : 'linux64.tar.gz'))
+        (isWin ? 'win64.zip' : (isMac ? 'macos.tar.gz' : 'linux64.tar.gz'))
       ),
       binaryName: 'geckodriver' + (isWin ? '.exe' : '')
     },


### PR DESCRIPTION
Starting from release 0.11.0 geckodriver is released with a different name format of the archive for macOS. Included change updates the configuration script to include that change.

Without the change the package fails to install and breaks installation of any package depending on it.

I could include a conditional to check the desired version of the geckodriver (as controlled by env vars) and build the URL based on that version, but deemed that too messy for the little gain it brings. Please correct me if I'm wrong on that.

On a more personal note I would really appreciate a prompt release that fixes this issue.